### PR TITLE
Remove X-Forwarded-For logic in Varnish 4 VCL

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -111,16 +111,6 @@ sub vcl_recv {
 
     {{https_redirect}}
 
-    # this always needs to be done so it's up at the top
-    if (req.restarts == 0) {
-        if (req.http.X-Forwarded-For) {
-            set req.http.X-Forwarded-For =
-                req.http.X-Forwarded-For + ", " + client.ip;
-        } else {
-            set req.http.X-Forwarded-For = client.ip;
-        }
-    }
-
     # We only deal with GET and HEAD by default
     # we test this here instead of inside the url base regex section
     # so we can disable caching for the entire site if needed


### PR DESCRIPTION
This is already taken care of in Varnish 4 internally.

See [upgrade notes](https://varnish-cache.org/docs/4.0/whats-new/upgrading.html#x-forwarded-for-is-now-set-before-vcl-recv) and [source file ](https://github.com/varnishcache/varnish-cache/blob/4.0/bin/varnishd/cache/cache_req_fsm.c#L724).